### PR TITLE
Fix wordpress path issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# vPOS woocommerce
+# vPOS WooCommerce
 
 <p align="center"><a href="#/"><img src="https://github.com/nextbss/vpos-woocommerce/blob/main/.wordpress-org/vpos-logo.png" alt="vPOS"></a></p>
 
-[![](https://img.shields.io/badge/nextbss-opensource-blue.svg)](https://www.nextbss.co.ao)
+[![](https://img.shields.io/badge/vPOS-OpenSource-blue.svg)](https://www.nextbss.co.ao)
 
 The number #1 payment solution in Angola
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The number #1 payment solution in Angola
 
 This plugin currently works for the solutions listed below:
 
-EMIS GPO (Multicaixa Express)
+- EMIS GPO (Multicaixa Express)
 
 ## Installation and Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vPOS WooCommerce
+# vPOS - WooCommerce
 
 <p align="center"><a href="#/"><img src="https://github.com/nextbss/vpos-woocommerce/blob/main/.wordpress-org/vpos-logo.png" alt="vPOS"></a></p>
 

--- a/handle.php
+++ b/handle.php
@@ -33,6 +33,11 @@ if ($gateway == null) {
 
 $settings = $gateway->settings;
 
+if ($settings == null) {
+    error_log("settings have not been defined");
+    exit(1);
+}
+
 $token = $settings['vpos_token'];
 $pos_id = $settings['gpo_pos_id'];
 $payment_url = $settings['vpos_payment_callback'];

--- a/handle.php
+++ b/handle.php
@@ -25,6 +25,12 @@ if (!defined('ABSPATH')) {
 }
 
 $gateway = WC()->payment_gateways->payment_gateways()['vpos'];
+
+if ($gateway == null) {
+    error_log("gateway has not been setup");
+    exit(1);
+}
+
 $settings = $gateway->settings;
 
 $token = $settings['vpos_token'];
@@ -32,11 +38,6 @@ $pos_id = $settings['gpo_pos_id'];
 $payment_url = $settings['vpos_payment_callback'];
 $refund_url = $settings['vpos_refund_callback'];
 $mode = $settings['vpos_environment'];
-
-if ($gateway == null) {
-    error_log("gateway has not been setup");
-    exit(1);
-}
 
 $handler = new RequestHandler();
 $vpos = new Vpos($pos_id, $token, $payment_url, $refund_url, $mode);

--- a/vpos-checkout.php
+++ b/vpos-checkout.php
@@ -641,7 +641,7 @@ if (empty($_COOKIE['vpos_merchant'])) {
 
     function completeOrder() {
       const orderId = <?php echo $_COOKIE['vpos_order_id']; ?>;
-      return axios.get("/wordpress/wp-content/plugins/vpos-woocommerce/handle.php?order_id=" + orderId + "&type=complete-order",
+      return axios.get("/wp-content/plugins/vpos-woocommerce/handle.php?order_id=" + orderId + "&type=complete-order",
       {validateStatus: (status => status < 300)})
       .then(function (response) {
         document.getElementById("url").innerText = "Ir para o sumário da compra"
@@ -656,7 +656,7 @@ if (empty($_COOKIE['vpos_merchant'])) {
     }
 
     function get(id) {
-      return axios.get("/wordpress/wp-content/plugins/vpos-woocommerce/handle.php?id=" + id + "&type=get",
+      return axios.get("/wp-content/plugins/vpos-woocommerce/handle.php?id=" + id + "&type=get",
       {validateStatus: (status => status < 400)})
       .then(function (response) {
         if (response.status == 200) {
@@ -693,7 +693,7 @@ if (empty($_COOKIE['vpos_merchant'])) {
     }
 
     function poll(id) {
-      return axios.get("/wordpress/wp-content/plugins/vpos-woocommerce/handle.php?id=" + id + "&type=poll"
+      return axios.get("/wp-content/plugins/vpos-woocommerce/handle.php?id=" + id + "&type=poll"
       ,{validateStatus: (status) => status < 400 })
       .then(function (response) {
           this.state = "processing";
@@ -713,7 +713,7 @@ if (empty($_COOKIE['vpos_merchant'])) {
       var form = new FormData();
       form.append('mobile', mobile_no_prefix);
       form.append('amount', parseFloat(amount));
-      return axios.post("/wordpress/wp-content/plugins/vpos-woocommerce/handle.php", 
+      return axios.post("/wp-content/plugins/vpos-woocommerce/handle.php", 
        form,
       headers)
       .then(response => {


### PR DESCRIPTION
This PR fixes the problem that caused a 404 when a customer tries to perform a payment.

The problem occurs because all http requests are routed to handle.php which is in the `vpos-woocommerce` folder.
Unfortunately the file `vpos-checkout.php` expects the location of the file to be inside a root folder called `wordpress` of the server running the wordpress application, which is not the usual place where wordpress is installed.

Often times, wordpress is installed in /var/www/html and not /var/www/html/wordpress.

How to fix?

We change vpos-checkout.php to point to a more general wp-content inside the root folder instead, since most installations of wordpress follow this configuration.

